### PR TITLE
Fix fake UVC device serial generated from VID/PID

### DIFF
--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/CameraManagerImpl.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/CameraManagerImpl.java
@@ -272,43 +272,66 @@ public class CameraManagerImpl extends DestructOnFinalize/*no parent*/ implement
 
     @Override @NonNull public List<LibUsbDevice> getMatchingLibUsbDevices(Function<SerialNumber, Boolean> matcher)
         {
-        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            {
+
             List<LibUsbDevice> result = new ArrayList<>();
             for (UsbDevice usbDevice : usbManager.getDeviceList().values())
-                {
+            {
                 SerialNumber candidate = getRealOrVendorProductSerialNumber(usbDevice);
                 if (candidate != null && matcher.apply(candidate))
-                    {
-                    LibUsbDevice libUsbDevice = getOrMakeUvcContext().getLibUsbDeviceFromUsbDeviceName(usbDevice.getDeviceName(), true);
+                {
+                    LibUsbDevice libUsbDevice = getOrMakeUvcContext().getLibUsbDeviceFromUsbDevice(usbDevice, true);
                     result.add(libUsbDevice);
-                    }
                 }
+            }
             return result;
-            }
-        else
-            {
-            return getOrMakeUvcContext().getMatchingLibUsbDevicesKitKat(matcher);
-            }
+
+//        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+//            {
+//            List<LibUsbDevice> result = new ArrayList<>();
+//            for (UsbDevice usbDevice : usbManager.getDeviceList().values())
+//                {
+//                SerialNumber candidate = getRealOrVendorProductSerialNumber(usbDevice);
+//                if (candidate != null && matcher.apply(candidate))
+//                    {
+//                    LibUsbDevice libUsbDevice = getOrMakeUvcContext().getLibUsbDeviceFromUsbDeviceName(usbDevice.getDeviceName(), true);
+//                    result.add(libUsbDevice);
+//                    }
+//                }
+//            return result;
+//            }
+//        else
+//            {
+//            return getOrMakeUvcContext().getMatchingLibUsbDevicesKitKat(matcher);
+//            }
         }
 
     @Override public void enumerateAttachedSerialNumbers(Consumer<SerialNumber> consumer)
         {
-        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            {
+
             for (UsbDevice usbDevice : usbManager.getDeviceList().values())
-                {
+            {
                 SerialNumber candidate = getRealOrVendorProductSerialNumber(usbDevice);
                 if (candidate != null)
-                    {
+                {
                     consumer.accept(candidate);
-                    }
                 }
             }
-        else
-            {
-            getOrMakeUvcContext().enumerateAttachedSerialNumbersKitKat(consumer);
-            }
+
+//        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+//            {
+//            for (UsbDevice usbDevice : usbManager.getDeviceList().values())
+//                {
+//                SerialNumber candidate = getRealOrVendorProductSerialNumber(usbDevice);
+//                if (candidate != null)
+//                    {
+//                    consumer.accept(candidate);
+//                    }
+//                }
+//            }
+//        else
+//            {
+//            getOrMakeUvcContext().enumerateAttachedSerialNumbersKitKat(consumer);
+//            }
         }
 
     @Override public WebcamName webcamNameFromDevice(UsbDevice usbDevice)
@@ -324,7 +347,7 @@ public class CameraManagerImpl extends DestructOnFinalize/*no parent*/ implement
 
     @Override public WebcamName webcamNameFromDevice(LibUsbDevice libUsbDevice)
         {
-        return WebcamNameImpl.forSerialNumber(libUsbDevice.getRealOrVendorProductSerialNumber());
+        return WebcamNameImpl.forSerialNumber(libUsbDevice.getRealOrVendorProductSerialNumberUsingJava());
         }
 
     @Override public BuiltinCameraName nameFromCameraDirection(VuforiaLocalizer.CameraDirection cameraDirection)

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/CameraManagerInternal.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/CameraManagerInternal.java
@@ -58,7 +58,7 @@ public interface CameraManagerInternal extends CameraManager
     {
     /* In early developmental work, there were paths necessary on KitKat that subsequent work
     * no longer requires (most had to do with serial numbers). Which should we use? */
-    boolean avoidKitKatLegacyPaths = true;
+    //boolean avoidKitKatLegacyPaths = true;
 
     /*If KitKat *has to* use one path, but there's a non-native one post KitKat, should we use it?*/
     boolean useNonKitKatPaths = true;

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/LibUsbDevice.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/LibUsbDevice.java
@@ -32,6 +32,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 package org.firstinspires.ftc.robotcore.internal.camera.libuvc.nativeobject;
 
+import android.hardware.usb.UsbDevice;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
@@ -60,21 +61,24 @@ public class LibUsbDevice extends NativeObject
     public static final String TAG = LibUsbDevice.class.getSimpleName();
     public String getTag() { return TAG; }
 
+    private UsbDevice javaUsbDevice;
+
     protected final boolean traceEnabled;
 
     //----------------------------------------------------------------------------------------------
     // Construction
     //----------------------------------------------------------------------------------------------
 
-    public LibUsbDevice(long pointer)
+    public LibUsbDevice(long pointer, UsbDevice javaUsbDevice)
         {
-        this(pointer, true);
+        this(pointer, javaUsbDevice, true);
         }
 
-    public LibUsbDevice(long pointer, boolean traceEnabled)
+    public LibUsbDevice(long pointer, UsbDevice javaUsbDevice, boolean traceEnabled)
         {
 		super(pointer, traceEnabled ? defaultTraceLevel : TraceLevel.None); // We assume ownership of the (native) ref count present in pointer
         this.traceEnabled = traceEnabled;
+        this.javaUsbDevice = javaUsbDevice;
         }
 
     @Override protected void destructor()
@@ -136,6 +140,19 @@ public class LibUsbDevice extends NativeObject
         else
             {
             return SerialNumber.fromVidPid(nativeGetVendorId(pointer), nativeGetProductId(pointer), getUsbConnectionPath());
+            }
+        }
+
+        public SerialNumber getRealOrVendorProductSerialNumberUsingJava()
+        {
+            String string = nativeGetSerialNumber(pointer, traceEnabled);
+            if (UsbSerialNumber.isValidUsbSerialNumber(string))
+            {
+                return SerialNumber.fromString(string);
+            }
+            else
+            {
+                return SerialNumber.fromVidPid(javaUsbDevice.getVendorId(), javaUsbDevice.getProductId(), getUsbConnectionPath());
             }
         }
 

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/UvcContext.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/UvcContext.java
@@ -182,24 +182,24 @@ public class UvcContext extends NativeObject
             }
         if (serialNumber==null) // Device lacks real serial number: go the long route so we make up a VendorProductSerialNumber
             {
-            LibUsbDevice libUsbDevice = getLibUsbDeviceFromUsbDeviceName(usbDevice.getDeviceName(), false);
+            LibUsbDevice libUsbDevice = getLibUsbDeviceFromUsbDevice(usbDevice, false);
             if (libUsbDevice != null)
                 {
-                serialNumber = libUsbDevice.getRealOrVendorProductSerialNumber();
+                serialNumber = libUsbDevice.getRealOrVendorProductSerialNumberUsingJava();
                 libUsbDevice.releaseRef();
                 }
             }
         return serialNumber;
         }
 
-    public @Nullable LibUsbDevice getLibUsbDeviceFromUsbDeviceName(String usbDeviceName, boolean traceEnabled)
+    public @Nullable LibUsbDevice getLibUsbDeviceFromUsbDevice(UsbDevice usbDevice, boolean traceEnabled)
         {
         synchronized (lock)
             {
-            long libUsbDevicePointer = nativeGetLibUsbDeviceFromUsbDeviceName(pointer, usbDeviceName);
+            long libUsbDevicePointer = nativeGetLibUsbDeviceFromUsbDeviceName(pointer, usbDevice.getDeviceName());
             if (libUsbDevicePointer != 0)
                 {
-                return new LibUsbDevice(libUsbDevicePointer, traceEnabled);
+                return new LibUsbDevice(libUsbDevicePointer, usbDevice, traceEnabled);
                 }
             return null;
             }
@@ -310,61 +310,61 @@ public class UvcContext extends NativeObject
         void accept(long value);
         }
 
-    public @NonNull List<LibUsbDevice> getMatchingLibUsbDevicesKitKat(final Function<SerialNumber, Boolean> matcher)
-        {
-        synchronized (lock)
-            {
-            final List<LibUsbDevice> result = new ArrayList<>();
-
-            nativeEnumerateAttachedLibUsbDevicesKitKat(pointer, new LongConsumer()
-                {
-                @Override public void accept(long libusbPointer)
-                    {
-                    LibUsbDevice libUsbDevice = new LibUsbDevice(libusbPointer, false); // takes ownership of the pointer
-                    try {
-                        SerialNumber candidate = libUsbDevice.getRealOrVendorProductSerialNumber();
-                        if (candidate != null && matcher.apply(candidate))
-                            {
-                            libUsbDevice.addRef();
-                            result.add(libUsbDevice);
-                            }
-                        }
-                    finally
-                        {
-                        libUsbDevice.releaseRef();
-                        }
-                    }
-                });
-
-            return result;
-            }
-        }
+//    public @NonNull List<LibUsbDevice> getMatchingLibUsbDevicesKitKat(final Function<SerialNumber, Boolean> matcher)
+//        {
+//        synchronized (lock)
+//            {
+//            final List<LibUsbDevice> result = new ArrayList<>();
+//
+//            nativeEnumerateAttachedLibUsbDevicesKitKat(pointer, new LongConsumer()
+//                {
+//                @Override public void accept(long libusbPointer)
+//                    {
+//                    LibUsbDevice libUsbDevice = new LibUsbDevice(libusbPointer, false); // takes ownership of the pointer
+//                    try {
+//                        SerialNumber candidate = libUsbDevice.getRealOrVendorProductSerialNumber();
+//                        if (candidate != null && matcher.apply(candidate))
+//                            {
+//                            libUsbDevice.addRef();
+//                            result.add(libUsbDevice);
+//                            }
+//                        }
+//                    finally
+//                        {
+//                        libUsbDevice.releaseRef();
+//                        }
+//                    }
+//                });
+//
+//            return result;
+//            }
+//        }
 
     /**
      * We're forced to do more work on KitKat. The world is much more efficient
      * on Lollipop and beyond: see the callers of this method.
      */
-    public void enumerateAttachedSerialNumbersKitKat(final Consumer<SerialNumber> consumer)
-        {
-        synchronized (lock)
-            {
-            nativeEnumerateAttachedLibUsbDevicesKitKat(pointer, new LongConsumer()
-                {
-                @Override public void accept(long libusbPointer)
-                    {
-                    LibUsbDevice libUsbDevice = new LibUsbDevice(libusbPointer, false); // takes ownership of the pointer
-                    try {
-                        SerialNumber candidate = libUsbDevice.getRealOrVendorProductSerialNumber();
-                        consumer.accept(candidate);
-                        }
-                    finally
-                        {
-                        libUsbDevice.releaseRef();
-                        }
-                    }
-                });
-            }
-        }
+//    public void enumerateAttachedSerialNumbersKitKat(final Consumer<SerialNumber> consumer)
+//        {
+//        synchronized (lock)
+//            {
+//            nativeEnumerateAttachedLibUsbDevicesKitKat(pointer, new LongConsumer()
+//                {
+//                @Override public void accept(long libusbPointer)
+//                    {
+//                    LibUsbDevice libUsbDevice = new LibUsbDevice(libusbPointer, false); // takes ownership of the pointer
+//                    try {
+//                        SerialNumber candidate = libUsbDevice.getRealOrVendorProductSerialNumber();
+//                        consumer.accept(candidate);
+//                        }
+//                    finally
+//                        {
+//                        libUsbDevice.releaseRef();
+//                        }
+//                    }
+//                });
+//            }
+//        }
 
     //----------------------------------------------------------------------------------------------
     // UVC device enumeration
@@ -511,14 +511,16 @@ public class UvcContext extends NativeObject
 
     public List<UvcDevice> getDeviceList() // throws NOTHING
         {
-        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            {
             return getUvcDeviceListUsingJava();
-            }
-        else
-            {
-            return getUvcDeviceListKitKat();
-            }
+
+//        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+//            {
+//            return getUvcDeviceListUsingJava();
+//            }
+//        else
+//            {
+//            return getUvcDeviceListKitKat();
+//            }
         }
 
     //----------------------------------------------------------------------------------------------

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/UvcDevice.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/libuvc/nativeobject/UvcDevice.java
@@ -85,7 +85,7 @@ public class UvcDevice extends NativeObject<UvcContext>
         super(thisPointer);
         try {
             setParent(uvcContext);
-            this.libUsbDevice = new LibUsbDevice(nativeGetLibUsbDevice(pointer));
+            this.libUsbDevice = new LibUsbDevice(nativeGetLibUsbDevice(pointer), usbDevice);
             this.usbDevice = usbDevice==null ? findUsbDevice() : usbDevice;
             this.webcamName = null;
             this.usbDeviceConnection = null;

--- a/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/names/WebcamNameImpl.java
+++ b/RobotCore/src/main/java/org/firstinspires/ftc/robotcore/internal/camera/names/WebcamNameImpl.java
@@ -189,65 +189,86 @@ public class WebcamNameImpl extends CameraNameImplBase implements WebcamNameInte
         {
         String result = null;
         if (isDuplicate != null) isDuplicate.setValue(false);
-        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            {
+
             boolean found = false;
             for (UsbDevice usbDevice : getUsbManager().getDeviceList().values())
-                {
+            {
                 SerialNumber candidate = cameraManagerInternal.getRealOrVendorProductSerialNumber(usbDevice);
                 if (candidate != null && candidate.matches(serialNumberPattern))
-                    {
+                {
                     if (!found)
-                        {
+                    {
                         result = usbDevice.getDeviceName();
                         found = true;
-                        }
+                    }
                     else
-                        {
+                    {
                         RobotLog.ee(TAG, "more than one webcam attached matching serial number %s: ignoring them all", serialNumberPattern);
                         result = null;
                         if (isDuplicate != null) isDuplicate.setValue(true);
-                        }
                     }
                 }
             }
-        else
-            {
-            List<LibUsbDevice> libUsbDevices = cameraManagerInternal.getMatchingLibUsbDevices(new Function<SerialNumber, Boolean>()
-                {
-                @Override public Boolean apply(SerialNumber candidate)
-                    {
-                    return candidate.matches(serialNumberPattern);
-                    }
-                });
-            try {
-                if (libUsbDevices.size()==0)
-                    {
-                    result = null; // device is not found
-                    }
-                else if (libUsbDevices.size()==1)
-                    {
-                    result = libUsbDevices.get(0).getUsbDeviceName();
-                    }
-                else
-                    {
-                    RobotLog.ee(TAG, "more than one webcam attached matching serial number %s: ignoring them all", serialNumberPattern);
-                    for (LibUsbDevice libUsbDevice : libUsbDevices)
-                        {
-                        RobotLog.ee(TAG, "libUsbDevice: name=%s connection=%s serial=%s", libUsbDevice.getUsbDeviceName(), libUsbDevice.getUsbConnectionPath(), libUsbDevice.getRealOrVendorProductSerialNumber());
-                        }
-                    result = null;
-                    if (isDuplicate != null) isDuplicate.setValue(true);
-                    }
-                }
-            finally
-                {
-                for (LibUsbDevice libUsbDevice : libUsbDevices)
-                    {
-                    libUsbDevice.releaseRef();
-                    }
-                }
-            }
+
+//        if (CameraManagerInternal.avoidKitKatLegacyPaths || Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+//            {
+//            boolean found = false;
+//            for (UsbDevice usbDevice : getUsbManager().getDeviceList().values())
+//                {
+//                SerialNumber candidate = cameraManagerInternal.getRealOrVendorProductSerialNumber(usbDevice);
+//                if (candidate != null && candidate.matches(serialNumberPattern))
+//                    {
+//                    if (!found)
+//                        {
+//                        result = usbDevice.getDeviceName();
+//                        found = true;
+//                        }
+//                    else
+//                        {
+//                        RobotLog.ee(TAG, "more than one webcam attached matching serial number %s: ignoring them all", serialNumberPattern);
+//                        result = null;
+//                        if (isDuplicate != null) isDuplicate.setValue(true);
+//                        }
+//                    }
+//                }
+//            }
+//        else
+//            {
+//            List<LibUsbDevice> libUsbDevices = cameraManagerInternal.getMatchingLibUsbDevices(new Function<SerialNumber, Boolean>()
+//                {
+//                @Override public Boolean apply(SerialNumber candidate)
+//                    {
+//                    return candidate.matches(serialNumberPattern);
+//                    }
+//                });
+//            try {
+//                if (libUsbDevices.size()==0)
+//                    {
+//                    result = null; // device is not found
+//                    }
+//                else if (libUsbDevices.size()==1)
+//                    {
+//                    result = libUsbDevices.get(0).getUsbDeviceName();
+//                    }
+//                else
+//                    {
+//                    RobotLog.ee(TAG, "more than one webcam attached matching serial number %s: ignoring them all", serialNumberPattern);
+//                    for (LibUsbDevice libUsbDevice : libUsbDevices)
+//                        {
+//                        RobotLog.ee(TAG, "libUsbDevice: name=%s connection=%s serial=%s", libUsbDevice.getUsbDeviceName(), libUsbDevice.getUsbConnectionPath(), libUsbDevice.getRealOrVendorProductSerialNumberUsingJava());
+//                        }
+//                    result = null;
+//                    if (isDuplicate != null) isDuplicate.setValue(true);
+//                    }
+//                }
+//            finally
+//                {
+//                for (LibUsbDevice libUsbDevice : libUsbDevices)
+//                    {
+//                    libUsbDevice.releaseRef();
+//                    }
+//                }
+//            }
         return result;
         }
 


### PR DESCRIPTION
This patch fixes the fake serial number generation using PID/VID for UVC devices.

The way the SDK identifies UVC devices is by their serial number. But if the UVC device doesn't have a serial, the SDK makes up a fake one from the PID and VID USB metadata. However, this latter functionality was broken, because the calls to get PID and VID were returning "0" and thus the fake serial number was "0:0". What's more, although UVC devices could be correctly detected (or have their absence detected) when their serial was "0:0", when you go to actually USE it (I tested with the Vuforia webcam example and my own webcam example for EasyOpenCV) it would not work correctly.

This patch fixes the PID and VID being reported as "0" by replacing the calls to native C++ code to get those values with calls to the Android Java API. The heart of the change is the diff for the LibUsbDevice.java file. The rest of the changes were simply things that had to be changed as the result of the change to LibUsbDevice.java. Some legacy code (which was already disabled thanks to a boolean flag) had to be commented out, but that really shouldn't be a big deal given that it was not actually being used at all....

I was testing with my UVC-compatible microscope, which does not report a serial number. Before the change it was detected as "0:0". After the change, it was detected as "7758:265".

Results when running Vuforia Webcam sample before change (no preview and/or crash), and after the change (works great!):

![Untitled-1](https://user-images.githubusercontent.com/26417650/79277598-1fa05d00-7e78-11ea-9d6d-a7edb02558e5.png)
